### PR TITLE
fix non-constructor arguments causing exceptions in DynamicProxyProxyFactory

### DIFF
--- a/src/Ninject.Extensions.Interception.DynamicProxy/DynamicProxyProxyFactory.cs
+++ b/src/Ninject.Extensions.Interception.DynamicProxy/DynamicProxyProxyFactory.cs
@@ -20,6 +20,7 @@ using Castle.DynamicProxy;
 using Ninject.Activation;
 using Ninject.Extensions.Interception.Wrapper;
 using Ninject.Infrastructure;
+using Ninject.Parameters;
 
 #endregion
 
@@ -90,7 +91,7 @@ namespace Ninject.Extensions.Interception.ProxyFactory
 
             var wrapper = new DynamicProxyWrapper(Kernel, context, reference.Instance);
             Type targetType = context.Request.Service;
-            object[] parameters = context.Parameters
+            object[] parameters = context.Parameters.OfType<ConstructorArgument>()
                 .Select(parameter => parameter.GetValue(context, null))
                 .ToArray();
 


### PR DESCRIPTION
We've been using inherited parameters to good effect but have hit problems with the interception extension when non-constructor arguments are passed in as constructor arguments to proxied classes.  This change checks that parameters are of type ConstructorArgument before passing them in to the generator as constructor arguments.
