### PR TITLE
Working with some obvuscated code that has Special methods that are less than three chars long (this one actually has no characters)

### DIFF
--- a/src/Ninject.Extensions.Interception/Infrastructure/Language/ExtensionsForMethodInfo.cs
+++ b/src/Ninject.Extensions.Interception/Infrastructure/Language/ExtensionsForMethodInfo.cs
@@ -29,7 +29,7 @@ namespace Ninject.Extensions.Interception.Infrastructure.Language
 
         public static PropertyInfo GetPropertyFromMethod( this MethodInfo method, Type implementingType )
         {
-            if ( !method.IsSpecialName )
+            if ( !method.IsSpecialName||method.Name.Length<4)
             {
                 return null;
             }


### PR DESCRIPTION
causes a crash but should just be treated as a non special method for this purpose
