### PR TITLE
Removed the IsGenericMethodDefinition check

### DIFF
--- a/src/Ninject.Extensions.Interception/Injection/InjectorFactoryBase.cs
+++ b/src/Ninject.Extensions.Interception/Injection/InjectorFactoryBase.cs
@@ -40,11 +40,10 @@ namespace Ninject.Extensions.Interception.Injection
         {
             lock ( _methodInjectors )
             {
-                if ( method.IsGenericMethodDefinition )
+                /*if ( method.IsGenericMethodDefinition )
                 {
-                    throw new InvalidOperationException(
-                        /*ExceptionFormatter.CannotCreateInjectorFromGenericTypeDefinition(method)*/ );
-                }
+                    throw new InvalidOperationException();
+                }*/
 
                 if ( _methodInjectors.ContainsKey( method ) )
                 {


### PR DESCRIPTION
Seems like the interceptors works on generic methods when using LinFu proxies.
