### PR TITLE
Allow interception of synchronous calls passing through this interceptor

### DIFF
--- a/src/Ninject.Extensions.Interception/AsyncInterceptor.cs
+++ b/src/Ninject.Extensions.Interception/AsyncInterceptor.cs
@@ -23,8 +23,9 @@ namespace Ninject.Extensions.Interception
         /// <summary>
         /// Intercepts the specified invocation.
         /// </summary>
+        /// <remarks>If overridden, you should invoke base.</remarks>
         /// <param name="invocation">The invocation to intercept.</param>
-        public void Intercept(IInvocation invocation)
+        public virtual void Intercept(IInvocation invocation)
         {
             var returnType = invocation.Request.Method.ReturnType;
             if (returnType == typeof(Task))


### PR DESCRIPTION
Since we invoke the syncronous calls, we should allow catching of them.

This allows the user more flexibility in what their interceptor can do while maintaining the async interception functionality.

I understand you can create another interceptor, this just helps ensure a user can be flexible in their usage within the single interceptor.