### PR TITLE
Update castle core

### DIFF
--- a/src/Ninject.Extensions.Interception.DynamicProxy/Ninject.Extensions.Interception.DynamicProxy.csproj
+++ b/src/Ninject.Extensions.Interception.DynamicProxy/Ninject.Extensions.Interception.DynamicProxy.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.2.0" />
+    <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Ninject.Extensions.Interception.DynamicProxy/ObjectMethodsInvocation.cs
+++ b/src/Ninject.Extensions.Interception.DynamicProxy/ObjectMethodsInvocation.cs
@@ -129,6 +129,12 @@ namespace Ninject.Extensions.Interception.ProxyFactory
             this.Method.Invoke(this.InvocationTarget, this.Arguments);
         }
 
+        /// <inheritdoc />
+        public IInvocationProceedInfo CaptureProceedInfo()
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Sets the argument value.
         /// </summary>


### PR DESCRIPTION
This PR updates the Castle.Core to 4.4.0 and adds an implementation for the `CaptureProceedInfo` method in the ObjectMethodsInvocation file.
This allows the project to work with the 4.4.0 version of the Castle.Core package.

This commit fixes issue #48 