### PR TITLE
Add check for faulted task in AsyncInterceptor

### DIFF
--- a/src/Ninject.Extensions.Interception.Test/AsyncInterceptionContext.cs
+++ b/src/Ninject.Extensions.Interception.Test/AsyncInterceptionContext.cs
@@ -87,7 +87,7 @@ namespace Ninject.Extensions.Interception
                 var result = await service.DoAsyncIntThrow();
 
                 BeforeAfterCallOrderInterceptor.Order.Should().Be("Before_Action_HandleException_AfterCompleted_");
-                result.Should().Be(default);
+                result.Should().Be(default(int));
             }
         }
 

--- a/src/Ninject.Extensions.Interception.Test/AsyncInterceptionContext.cs
+++ b/src/Ninject.Extensions.Interception.Test/AsyncInterceptionContext.cs
@@ -1,5 +1,6 @@
 namespace Ninject.Extensions.Interception
 {
+    using System;
     using System.Threading.Tasks;
     using FluentAssertions;
     using Ninject.Extensions.Interception.Infrastructure.Language;
@@ -20,6 +21,22 @@ namespace Ninject.Extensions.Interception
                 await service.DoAsync();
 
                 BeforeAfterCallOrderInterceptor.Order.Should().Be("Before_Action_AfterCompleted_");
+            }
+        }
+
+        [Fact]
+        public async Task AsyncMethods_InterceptorsCanCatchException()
+        {
+            using (var kernel = this.CreateDefaultInterceptionKernel())
+            {
+                BeforeAfterCallOrderInterceptor.Reset();
+
+                kernel.Bind<AsyncService>().ToSelf().Intercept().With<BeforeAfterCallOrderInterceptor>();
+                var service = kernel.Get<AsyncService>();
+
+                await service.DoAsyncThrow();
+
+                BeforeAfterCallOrderInterceptor.Order.Should().Be("Before_Action_HandleException_AfterCompleted_");
             }
         }
 
@@ -57,17 +74,62 @@ namespace Ninject.Extensions.Interception
             }
         }
 
+        [Fact]
+        public async Task AsyncMethodsWithReturnValue_InterceptorsCanCatchException()
+        {
+            using (var kernel = this.CreateDefaultInterceptionKernel())
+            {
+                BeforeAfterCallOrderInterceptor.Reset();
+
+                kernel.Bind<AsyncService>().ToSelf().Intercept().With<BeforeAfterCallOrderInterceptor>();
+                var service = kernel.Get<AsyncService>();
+
+                var result = await service.DoAsyncIntThrow();
+
+                BeforeAfterCallOrderInterceptor.Order.Should().Be("Before_Action_HandleException_AfterCompleted_");
+                result.Should().Be(default);
+            }
+        }
+
+        [Fact]
+        public async Task AsyncMethodsWithReturnValue_InterceptorsSetDefaultReturnValueOnFault()
+        {
+            using (var kernel = this.CreateDefaultInterceptionKernel())
+            {
+                BeforeAfterCallOrderInterceptor.Reset();
+
+                kernel.Bind<AsyncService>().ToSelf().Intercept().With<IncreaseResultInterceptor>();
+                var service = kernel.Get<AsyncService>();
+
+                var result = await service.DoAsyncIntThrow();
+
+                BeforeAfterCallOrderInterceptor.Order.Should().Be("Before_Action_HandleException_AfterCompleted_");
+                result.Should().Be(1);
+            }
+        }
+
         public class AsyncService
         {
+            public virtual async Task DoAsync()
+            {
+                await this.Do();
+            }
+
             public virtual async Task<int> DoAsyncInt()
             {
                 int result = await this.DoInt();
                 return result;
             }
 
-            public virtual async Task DoAsync()
+            public virtual async Task DoAsyncThrow()
             {
-                await this.Do();
+                await this.DoThrow();
+            }
+
+            public virtual async Task<int> DoAsyncIntThrow()
+            {
+                int result = await this.DoIntThrow();
+                return result;
             }
 
             private Task Do()
@@ -76,10 +138,22 @@ namespace Ninject.Extensions.Interception
                 return Task.Delay(100);
             }
 
+            private Task DoThrow()
+            {
+                BeforeAfterCallOrderInterceptor.ActionCalled();
+                throw new Exception();
+            }
+
             private Task<int> DoInt()
             {
                 BeforeAfterCallOrderInterceptor.ActionCalled();
                 return Task.Delay(100).ContinueWith((t, o) => 42, null);
+            }
+
+            private Task<int> DoIntThrow()
+            {
+                BeforeAfterCallOrderInterceptor.ActionCalled();
+                throw new Exception();
             }
         }
 
@@ -115,6 +189,11 @@ namespace Ninject.Extensions.Interception
                 {
                     Order += "BeforeCompleted_";
                 }
+            }
+
+            protected override void HandleException(IInvocation invocation, Exception e)
+            {
+                Order += "HandleException_";
             }
         }
 


### PR DESCRIPTION
See #52.  This PR adds a check to `task.IsFaulted` in the post-invoke continuations for the AsyncInterceptor.  Exceptions can then be handled via `HandleException()` rather than throwing when the `task.Result` is accessed on a faulted task.

Full unit tests are included.